### PR TITLE
Opds-pse v1.2 [LastRead], serverFileName fallback & ImageViewer (Fit to Width button)

### DIFF
--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -194,6 +194,19 @@ function ImageViewer:init()
                 end,
             },
             {
+                id = "scale_width",
+                text = _("Fit to Width"),
+                callback = function()
+                    if self.image:getWidth() and self.width then
+                        self.scale_factor = self.width / self.image:getWidth()
+                        self._center_x_ratio = 0.5
+                        self._center_y_ratio = 0.0
+                        self._scale_to_fit = false
+                        self:update()
+                    end
+                end,
+            },
+            {
                 id = "rotate",
                 text = self.rotated and _("No rotation") or _("Rotate"),
                 callback = function()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -787,18 +787,18 @@ function OPDSBrowser.getCurrentDownloadDir()
 end
 
 function OPDSBrowser:getLocalDownloadPath(filename, filetype, remote_url, filename_orig)
-    local fileNameFromServer
+    local filename_from_server
     if self.root_catalog_raw_names then
-        fileNameFromServer = self:getServerFileName(remote_url)
-    end
-    -- if fileNameFromServer is not found and use filename_orig instead
-    if not fileNameFromServer or fileNameFromServer == "" then
-        logger.warn("No fileName found: falling back to default name")
-        fileNameFromServer = filename_orig
+        filename_from_server = self:getServerFileName(remote_url)
+        -- if fileNameFromServer is not found and use filename_orig instead
+        if not filename_from_server or filename_from_server == "" then
+            logger.warn("No fileName found: falling back to default name")
+            filename_from_server = filename_orig .. "." .. filetype:lower()
+        end
     end
 
     local download_dir = OPDSBrowser.getCurrentDownloadDir()
-    filename = filename and filename .. "." .. filetype:lower() or fileNameFromServer
+    filename = filename and filename .. "." .. filetype:lower() or filename_from_server
     filename = util.getSafeFilename(filename, download_dir)
     filename = (download_dir ~= "/" and download_dir or "") .. '/' .. filename
     return util.fixUtf8(filename, "_")

--- a/plugins/opds.koplugin/opdspse.lua
+++ b/plugins/opds.koplugin/opdspse.lua
@@ -92,7 +92,7 @@ function OPDSPSE:getLastPage(remote_url, username, password)
     return last_page;
 end
 
-function OPDSPSE:streamPages(remote_url, count, continue, username, password)
+function OPDSPSE:streamPages(remote_url, count, continue, username, password, lastPageRead)
     -- attempt to pull chapter progress from Kavita if user pressed
     -- "Page Stream" button.
     -- We have to pull the progress here, otherwise the creation of the page_table
@@ -159,6 +159,9 @@ function OPDSPSE:streamPages(remote_url, count, continue, username, password)
     UIManager:show(viewer)
     if continue then
         self:jumpToPage(viewer, count)
+    elseif lastPageRead then
+        -- Switch to the last page that was read
+        viewer:switchToImageNum(lastPageRead)
     else
         -- add 1 since Kavita's Page count is zero based
         -- and ImageViewer is not.


### PR DESCRIPTION
### Changes
- Added OPDS-PSE v1.2 [lastRead] support in the download dialog whenever pse:lastRead is present.
    - Since the Page Stream option now has three buttons, I added a sub-dialog—clicking "Page Stream" now opens another dialog with all three options.
    - Clicking "Resume From Page N" now directs the ImageViewer to open the correct page directory.
- ImageViewer: Added a "Fit to Width" button. While "Scale to Fit" works fine, I wanted an option that fits the image to width for better readability and scrollability. The "Original Size" option wasn’t cutting it.
- Fix for serverFileName issues: If the endpoint doesn’t return proper headers on a HEAD request, the filename was failing, causing an error saying "Is a directory" because serverFileName was empty. Now, it falls back to the original/default filename, and if the filename is modified, it correctly retains that change.

### Screenshots
<details>
<summary> Page Stream Button & Dialog </summary>

![Page Stream Button](https://github.com/user-attachments/assets/4ec2b963-39a6-4dd2-a75e-61a33540df7f)
![Page Stream Dialog](https://github.com/user-attachments/assets/0f2397bd-ff05-4166-897e-07d68a0c6212)

</details>
<details>
<summary> Image Viewer (Fit to Width) </summary>


https://github.com/user-attachments/assets/08180604-ee31-415f-abba-5e06ab22f97a
</details>

</details>
<details>
<summary> Raw File name enabled (existing) </summary>

https://github.com/user-attachments/assets/743a597d-0cba-44c6-948d-23f3048aeddb
</details>

<details>
<summary> Raw File name enabled (this change) </summary>

https://github.com/user-attachments/assets/dbf7cee2-ed29-480d-9abc-74cabf9856b7
</details>